### PR TITLE
fix: Revert update nosborn/github-action-markdown-cli action to v3.0.0

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 1
 
       - name: markdownlint-cli
-        uses: nosborn/github-action-markdown-cli@v3.0.0
+        uses: nosborn/github-action-markdown-cli@v2.0.0
         with:
           files: "README.md docs/**"
           config_file: ".github/markdownlint.config.yaml"


### PR DESCRIPTION
Reverts bjw-s/home-ops#2086