### PR TITLE
fix: revert update docker image esphome/esphome to 2021.12.2

### DIFF
--- a/k8s/clusters/cluster-0/manifests/home-automation/esphome/helmrelease.yaml
+++ b/k8s/clusters/cluster-0/manifests/home-automation/esphome/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
   values:
     image:
       repository: esphome/esphome
-      tag: 2021.12.2
+      tag: 2021.12.1
 
     podAnnotations:
       backup.velero.io/backup-volumes: config


### PR DESCRIPTION
Reverts bjw-s/home-ops#2091