### PR TITLE
Ingress has incorrect indentation according to rook-ceph-cluster helm values

### DIFF
--- a/kubernetes/main/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/main/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -99,8 +99,8 @@ spec:
               - name: "/dev/disk/by-id/nvme-CT1000P1SSD8_202228759489"
 
     ingress:
-      ingressClassName: "internal-nginx"
       dashboard:
+        ingressClassName: "internal-nginx"
         annotations:
           nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
         host:


### PR DESCRIPTION
Just noticed your indentation seems wrong. Caught it while setting up a new cluster for myself. 

https://github.com/rook/rook/blob/8e704fdfd32eedccacba876d1d6373d4f7486b62/deploy/charts/rook-ceph-cluster/values.yaml#L440