### PR TITLE
fix: add ` --skip-diff-on-install` as well to helmfile command

### DIFF
--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -36,7 +36,7 @@ tasks:
     desc: Bootstrap core integrations needed for Talos
     cmds:
       - until kubectl --context {{.cluster}} wait --for=condition=Ready=False nodes --all --timeout=600s; do sleep 10; done
-      - helmfile --kube-context {{.cluster}} --file {{.KUBERNETES_DIR}}/{{.cluster}}/bootstrap/talos/integrations/helmfile.yaml apply --suppress-diff
+      - helmfile --kube-context {{.cluster}} --file {{.KUBERNETES_DIR}}/{{.cluster}}/bootstrap/talos/integrations/helmfile.yaml apply --skip-diff-on-install --suppress-diff
       - until kubectl --context {{.cluster}} wait --for=condition=Ready nodes --all --timeout=600s; do sleep 10; done
     requires:
       vars:


### PR DESCRIPTION
This _should_ also make it so you don't need the helm diff plugin command installed. Not sure why they have two flags that do the same thing /shrug